### PR TITLE
Add SkillOpt: Executive Strategy for Self-Evolving Agent Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Methods that improve prompts, memory, verification, tools, or agent policies aro
 - [EvoHarness-RL: Learning Self-Evolving Runtime Harness for Long-Horizon LLM Agents](https://arxiv.org/abs/2608.05446) - Trains agents to construct and coordinate evolving Belief, Progress, and Experience state during long-horizon execution. (COLM 2026 LLA Workshop)
 - [MemoHarness: Agent Harnesses That Learn from Experience](https://arxiv.org/abs/2607.14159) - Learns case-adaptive configurations across six harness control dimensions from execution diagnoses and a reusable experience bank. (arXiv 2026)
 - [MetaSkill-Evolve: Recursive Self-Improvement of LLM Agents via Two-Timescale Meta-Skill Evolution](https://arxiv.org/abs/2607.05297) - Evolves task skills in a fast loop and the meta-skills governing its Analyzer, Retriever, Allocator, Proposer, and Evolver in a slower recursive loop. (arXiv 2026)
+- [SkillOpt: Executive Strategy for Self-Evolving Agent Skills](https://arxiv.org/abs/2605.23904) - Trains a single skill document as the external state of a frozen agent, with a separate optimizer model proposing bounded edits accepted only on strict held-out validation gains. (arXiv 2026)
 
 ### Extensible Harness Substrates
 


### PR DESCRIPTION
## Description

Adds one entry to **Harness-level RSI > Harness & Scaffold Evolution** (alphabetical position within 2026 entries, at the end of the subsection).

- [SkillOpt: Executive Strategy for Self-Evolving Agent Skills](https://arxiv.org/abs/2605.23904) - Trains a single skill document as the external state of a frozen agent, with a separate optimizer model proposing bounded edits accepted only on strict held-out validation gains. (arXiv 2026)

## Required answers

**1. What is being improved?**
A single agent skill document — harness-level external state of a frozen agent — via bounded add/delete/replace edits proposed by a separate optimizer model; the agent's weights are unchanged.

**2. Does the improvement persist across iterations?**
Yes — accepted edits accumulate in the skill document behind strict held-out validation gating, and optimized skills transfer across model scales, execution harnesses (direct chat, Codex, Claude Code), and a nearby math benchmark without further optimization.

**3. Is the improvement mechanism itself subject to improvement?**
Not in this work — the optimizer is a separate model with engineered stabilization (textual learning-rate budget, rejected-edit buffer, epoch-wise meta updates), not itself optimized. This is bounded persistent self-improvement, which the guidelines explicitly accept.

**4. Why is this specifically relevant to RSI?**
It brings weight-space optimization discipline (validation-gated acceptance, stability mechanisms) to skill artifacts as trainable external state of a frozen agent, evaluated inside real coding-agent harnesses — squarely this list's scope of persistent self-improvement across skills and harness.

**5. Publication status:**
arXiv preprint (2026), v2 May 2026; code at aka.ms/skillopt.

## Checklist

- [x] Searched for duplicates (no SkillOpt / arXiv 2605.23904 entry exists)
- [x] One resource per PR
- [x] Entry follows the required format with a stable primary link
- [x] Placed in the most specific applicable subsection, ordered per the guidelines (newest year first; alphabetical within the same year)
- [x] `npx --yes awesome-lint@2.3.0` passes on this branch

I agree to have this contribution released under the repository's CC0 1.0 Universal license.
