### PR TITLE
Add First Steps Toward Automated AI Research (Recursive)

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,7 +229,6 @@ Mixes current-run repair loops with methods whose learned improvements persist i
 
 Systems that automate parts of AI research and development, including experimentation, post-training, algorithm discovery, and the improvement of other AI systems.
 
-- [First Steps Toward Automated AI Research](https://www.recursive.com/articles/first-steps-toward-automated-ai-research) - Describes an automated research system that closes the full loop from idea proposal through implementation, experiments, validation, and selection of the next experiment, with three reported SOTA results and open-sourced artifacts. (tech report 2026)
 - [Frontis-MA1: Training an AI4AI Model towards Recursive Self-Improvement in Machine Learning Engineering](https://arxiv.org/abs/2607.28568) - Connects execution-grounded operator training with long-horizon evolution in the open OpenMLE stack, using machine-learning engineering as an AI4AI testbed for RSI. (arXiv 2026)
 - [FT-Dojo: Towards Autonomous LLM Fine-Tuning with Language Agents](https://arxiv.org/abs/2603.01712) - Turns data collection, training, evaluation, diagnosis, and strategy revision into an executable environment for autonomous fine-tuning agents. (arXiv 2026)
 - [MLEvolve: A Self-Evolving Framework for Automated Machine Learning Algorithm Discovery](https://arxiv.org/abs/2606.06473) - Combines progressive graph search, retrospective memory, and hierarchical code generation for long-horizon end-to-end machine-learning algorithm discovery. (arXiv 2026)
@@ -363,6 +362,7 @@ Benchmarks grouped by how directly they provide evidence about recursive self-im
 ## Blog Posts & Discussions
 
 - [A Taxonomy of Self-Evolving Agents](https://lsl.zone/blog/2026/a-taxonomy-of-self-evolving-agents/) - Distinguishes Model, Harness, and Artifact evolution, complementing this list's own taxonomy. (2026)
+- [First Steps Toward Automated AI Research](https://recursive.com/articles/first-steps-toward-automated-ai-research) - Describes an automated research system that closes the full loop from idea proposal through implementation, experiments, validation, and selection of the next experiment, with three reported SOTA results and open-sourced artifacts. (2026)
 - [Harness Engineering for Self-Improvement](https://lilianweng.github.io/posts/2026-07-04-harness/) - Survey of harness engineering as a near-term path to recursive self-improvement, covering harness design patterns, context and workflow optimization, self-improving harnesses, evolutionary search, and joint optimization with model weights. (2026)
 - [AlphaEvolve: A Gemini-Powered Coding Agent for Designing Advanced Algorithms](https://deepmind.google/blog/alphaevolve-a-gemini-powered-coding-agent-for-designing-advanced-algorithms/) - Google DeepMind explains AlphaEvolve's evaluator-guided evolution loop and its applications to computing and AI training. (2025)
 - [The Darwin Gödel Machine: AI That Improves Itself by Rewriting Its Own Code](https://sakana.ai/dgm/) - Sakana AI explains DGM's empirical alternative to proof-based Gödel Machine self-modification. (2025)

--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Mixes current-run repair loops with methods whose learned improvements persist i
 
 Systems that automate parts of AI research and development, including experimentation, post-training, algorithm discovery, and the improvement of other AI systems.
 
+- [First Steps Toward Automated AI Research](https://www.recursive.com/articles/first-steps-toward-automated-ai-research) - Describes an automated research system that closes the full loop from idea proposal through implementation, experiments, validation, and selection of the next experiment, with three reported SOTA results and open-sourced artifacts. (tech report 2026)
 - [Frontis-MA1: Training an AI4AI Model towards Recursive Self-Improvement in Machine Learning Engineering](https://arxiv.org/abs/2607.28568) - Connects execution-grounded operator training with long-horizon evolution in the open OpenMLE stack, using machine-learning engineering as an AI4AI testbed for RSI. (arXiv 2026)
 - [FT-Dojo: Towards Autonomous LLM Fine-Tuning with Language Agents](https://arxiv.org/abs/2603.01712) - Turns data collection, training, evaluation, diagnosis, and strategy revision into an executable environment for autonomous fine-tuning agents. (arXiv 2026)
 - [MLEvolve: A Self-Evolving Framework for Automated Machine Learning Algorithm Discovery](https://arxiv.org/abs/2606.06473) - Combines progressive graph search, retrospective memory, and hierarchical code generation for long-horizon end-to-end machine-learning algorithm discovery. (arXiv 2026)


### PR DESCRIPTION
## Description

Adds one entry at the top of **Automated AI R&D** (newest year first; alphabetical within 2026: "First Steps…" < "Frontis-MA1").

- [First Steps Toward Automated AI Research](https://www.recursive.com/articles/first-steps-toward-automated-ai-research) - Describes an automated research system that closes the full loop from idea proposal through implementation, experiments, validation, and selection of the next experiment, with three reported SOTA results and open-sourced artifacts. (tech report 2026)

## Required answers

**1. What is being improved?**
Research artifacts themselves — training recipes and GPU kernels — improved through an autonomous propose-implement-run-validate loop, with three reported results: NanoChat Autoresearch (0.9109 BPB vs. prior best 0.9372), NanoGPT Speedrun (79.7 s → 77.5 s), and SOL-ExecBench kernel optimization (mean SOL 0.754 vs. previous leaderboard best 0.699).

**2. Does the improvement persist across iterations?**
Yes — validated findings are used to select the next experiment, context is retained across long-horizon research threads, and the resulting artifacts are open-sourced.

**3. Is the improvement mechanism itself subject to improvement?**
Not yet — the post explicitly positions these as first steps toward recursive self-improvement; the loop optimizes benchmarks, not its own capabilities.

**4. Why is this specifically relevant to RSI?**
It is a working automated AI research loop (AI doing AI research) with concrete SOTA-level evidence and reward-hack screening built into the loop — the seed capability this list's Automated AI R&D category tracks.

**5. Publication status:**
Technical blog post, Recursive (Jun 2026); artifacts open-sourced at github.com/recursive-org/first-steps-toward-automated-ai-research.

## Checklist

- [x] Searched for duplicates (no recursive.com entry exists)
- [x] One resource per PR
- [x] Entry follows the required format with a stable primary link
- [x] Placed in the most specific applicable subsection, ordered per the guidelines
- [x] `npx --yes awesome-lint@2.3.0` passes on this branch

I agree to have this contribution released under the repository's CC0 1.0 Universal license.
