### PR TITLE
Add MLS-Bench: A Holistic and Rigorous Assessment of AI Systems on Machine Learning Science

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ Benchmarks grouped by how directly they provide evidence about recursive self-im
 
 ### Automated AI R&D Evaluations
 
+- [MLS-Bench: A Holistic and Rigorous Assessment of AI Systems on Machine Learning Science](https://arxiv.org/abs/2605.08678) - Benchmark of 140 tasks across 12 ML research domains measuring whether AI systems can invent generalizable and scalable ML methods. (arXiv 2026)
 - [MLE-bench](https://github.com/openai/mle-bench) - Measures end-to-end machine-learning engineering performance across 75 Kaggle competitions and is used to track model self-improvement capability. (ICLR 2025)
 - [PaperBench](https://github.com/openai/frontier-evals/tree/main/project/paperbench) - Evaluates agents on replicating state-of-the-art AI research from paper descriptions. (ICML 2025)
 - [RE-Bench](https://github.com/METR/RE-Bench) - Compares AI agents with human experts on open-ended machine-learning research-engineering tasks under fixed time budgets. (ICML 2025)


### PR DESCRIPTION
## Description

Adds one entry to **Benchmarks & Evaluations > Automated AI R&D Evaluations** (2026 before the 2025 group; alphabetical within 2026: AutoLab (#7) → FrontierCS → MLS-Bench). Sibling PRs touch adjacent lines; I will rebase as they merge to keep this ordering.

- [MLS-Bench: A Holistic and Rigorous Assessment of AI Systems on Machine Learning Science](https://arxiv.org/abs/2605.08678) - Benchmark of 140 tasks across 12 ML research domains measuring whether AI systems can invent generalizable and scalable ML methods. (arXiv 2026)

## Required answers

**1. What is being improved?**
Nothing — this is an evaluation resource. It measures whether AI systems can invent generalizable and scalable machine-learning methods — rather than apply known ones — across 140 tasks in 12 ML research domains, with an official 30-task Lite subset and public leaderboard.

**2. Does the improvement persist across iterations?**
Not applicable — evaluation evidence, which the contribution guidelines explicitly accept as in scope.

**3. Is the improvement mechanism itself subject to improvement?**
Not applicable.

**4. Why is this specifically relevant to RSI?**
Inventing better ML methods is the core of AI improving AI; MLS-Bench directly measures that capability, making it a natural evaluation companion to the Automated AI R&D systems this list collects (Frontis-MA1, MLEvolve) alongside MLE-bench, PaperBench, and RE-Bench.

**5. Publication status:**
arXiv preprint (2026); code and tasks open-sourced (github.com/Imbernoulli/MLS-Bench, Hugging Face datasets).

## Checklist

- [x] Searched for duplicates (no MLS-Bench / arXiv 2605.08678 entry exists)
- [x] One resource per PR
- [x] Entry follows the required format with a stable primary link
- [x] Placed in the most specific applicable subsection, ordered per the guidelines
- [x] `npx --yes awesome-lint@2.3.0` passes on this branch

I agree to have this contribution released under the repository's CC0 1.0 Universal license.
