### PR TITLE
docs: add artifact availability metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest-resource.yml
+++ b/.github/ISSUE_TEMPLATE/suggest-resource.yml
@@ -75,6 +75,29 @@ body:
       placeholder: "conference: ICML (2025)"
     validations:
       required: true
+  - type: textarea
+    id: public-artifacts
+    attributes:
+      label: Public artifacts
+      description: List the public artifacts available for reproducing reported evaluations. Enter "Not applicable" if the resource does not report an evaluation.
+      placeholder: |
+        Official implementation:
+        Public data / checkpoints:
+        Public evaluation harness:
+    validations:
+      required: true
+  - type: dropdown
+    id: evaluation-artifact-status
+    attributes:
+      label: Evaluation artifact status
+      description: Select the artifact availability classification defined in CONTRIBUTING.md.
+      options:
+        - Open
+        - Partial
+        - Internal
+        - Not applicable
+    validations:
+      required: true
   - type: checkboxes
     id: duplicate-check
     attributes:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,6 +24,14 @@
 
 <!-- Identify the status and include the venue and year where applicable, for example: arXiv preprint (2026), workshop: AutoRL@ICML (2024), conference: ICML (2025), or journal: Nature (2026). -->
 
+### Public artifacts
+Official implementation:
+Public data / checkpoints:
+Public evaluation harness:
+
+### Evaluation artifact status
+Open / Partial / Internal / Not applicable
+
 ## Checklist
 
 - [ ] I searched the list and open pull requests for duplicates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,6 +35,21 @@ Difficulty alone is insufficient for inclusion.
 General knowledge and closed-ended reasoning benchmarks are out of scope unless
 there is specific evidence connecting them to self-improvement capability.
 
+## Artifact Availability
+
+Entries that report evaluations should state which artifacts are public.
+
+Open
+The task set or generative task source, scoring logic, and evaluation harness
+needed to rerun the evaluation are publicly available.
+
+Partial
+Some important artifacts are public, but a material part of the data,
+infrastructure, evaluation set, or execution environment is unavailable.
+
+Internal
+The reported evaluation materially depends on non-public tasks or infrastructure.
+
 ## Entry Format
 
 Use this format:


### PR DESCRIPTION
## Summary

- define Open, Partial, and Internal artifact availability in CONTRIBUTING.md
- collect public artifact links and evaluation artifact status in the pull request template and resource suggestion form
- track the repository-wide benchmark audit in #14 without adding status markers to README

## Validation

- `npx --yes awesome-lint@2.3.0`
- parsed `.github/ISSUE_TEMPLATE/suggest-resource.yml` as YAML
- confirmed README.md, workflows, and CITATION.cff are unchanged