### PR TITLE
Add AutoResearch: Insight In, Hallucination Out

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Mixes current-run repair loops with methods whose learned improvements persist i
 
 Systems that automate parts of AI research and development, including experimentation, post-training, algorithm discovery, and the improvement of other AI systems.
 
+- [AutoResearch: Insight In, Hallucination Out](https://arxiv.org/abs/2608.17906) - Connects grounded idea generation with coordinated execution agents that implement, diagnose, and independently review experiments before accepting research conclusions. (arXiv 2026)
 - [Frontis-MA1: Training an AI4AI Model towards Recursive Self-Improvement in Machine Learning Engineering](https://arxiv.org/abs/2607.28568) - Connects execution-grounded operator training with long-horizon evolution in the open OpenMLE stack, using machine-learning engineering as an AI4AI testbed for RSI. (arXiv 2026)
 - [FT-Dojo: Towards Autonomous LLM Fine-Tuning with Language Agents](https://arxiv.org/abs/2603.01712) - Turns data collection, training, evaluation, diagnosis, and strategy revision into an executable environment for autonomous fine-tuning agents. (arXiv 2026)
 - [MLEvolve: A Self-Evolving Framework for Automated Machine Learning Algorithm Discovery](https://arxiv.org/abs/2606.06473) - Combines progressive graph search, retrospective memory, and hierarchical code generation for long-horizon end-to-end machine-learning algorithm discovery. (arXiv 2026)


### PR DESCRIPTION
## Description

Adds one entry at the top of **Automated AI R&D** (2026 group, alphabetical: AutoResearch before Frontis-MA1).

- [AutoResearch: Insight In, Hallucination Out](https://arxiv.org/abs/2608.17906) - Connects grounded idea generation with coordinated execution agents that implement, diagnose, and independently review experiments before accepting research conclusions. (arXiv 2026)

## Required answers

**1. What is being improved?**
The automation target is the AI/ML research workflow itself: research plans, experiment implementations, and the experimental conclusions the system accepts. AutoResearch runs a two-stage loop from Idea Generation (integrating emerging research signals with accumulated domain knowledge) to Idea Execution (coordinated agents that decompose, implement, diagnose, and independently review experiments).

**2. Does the improvement persist across iterations?**
Yes. Accumulated domain knowledge carries across research cycles in Idea Generation, and the workflow is stateful and recoverable: plans, code, run logs, metrics, failure causes, critic reports, and blind reviews are written to disk and drive evidence-conditioned decisions to continue, revise, or terminate research directions.

**3. Is the improvement mechanism itself subject to improvement?**
The system revises its own research plans and directions from audited evidence, but its agent implementation is not self-modified; this is automated AI research rather than strict RSI, consistent with the scope of this section.

**4. Why is this specifically relevant to RSI?**
Automated AI R&D is the seed capability for recursive self-improvement, and this section already collects such systems. AutoResearch specifically targets the reliability bottleneck of autonomous research loops — keeping generated insight grounded before experimentation and conclusions grounded before acceptance — reporting 5 audit-confirmed issue events versus 11–27 for other autonomous research systems, alongside measurable gains such as RSICD mean Recall 32.84 to 34.69.

**5. Publication status:**
arXiv preprint (2026), arXiv:2608.17906.

**6. Public artifacts and evaluation artifact status:**
The system implementation is fully open at [github.com/EvoMap/AutoResearch](https://github.com/EvoMap/AutoResearch) (Apache-2.0), a stateful workflow whose plans, code, run logs, metrics, critic reports, and blind reviews are written to disk for inspection. For the reported evaluations the status is Partial: the case studies use public benchmarks such as RSICD, but the specific run artifacts behind the reported numbers are not packaged in the repository.

## Disclosure

I am a co-author of this paper.

## Checklist

- [x] Searched the list and open pull requests for duplicates (no AutoResearch / arXiv 2608.17906 entry exists; the unrelated karpathy/autoresearch tool under Frameworks & Tools is a different resource)
- [x] One resource per PR
- [x] Entry follows the required format with a stable primary link
- [x] Placed in the most specific applicable subsection, ordered per the guidelines
- [x] `npx --yes awesome-lint@2.3.0` passes on this branch

I agree to have this contribution released under the repository's CC0 1.0 Universal license.
