### PR TITLE
Add RecurSE: Bounded Recursive Self-Evaluation for LLM Rubric Judges

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Methods that improve model weights or training behavior through self-generated f
 
 ### Self-Training & Self-Reward
 
+- [RecurSE: Bounded Recursive Self-Evaluation for LLM Rubric Judges](https://arxiv.org/abs/2608.24231) - RecurSE trains LLM judges in a closed‑loop self‑evaluation where a synchronized checker audits reasoning to provide process rewards, while interface decoupling and PAV early stopping ensure bounded improvement without external gold labels. (arXiv 2026)
 - [EvoLM: Self-Evolving Language Models through Co-Evolved Discriminative Rubrics](https://arxiv.org/abs/2605.03871) - Alternately trains one model to generate discriminative rubrics and improve its policy from rubric-conditioned rewards without human annotations or external reward models. (arXiv 2026)
 - [RLAIF vs. RLHF: Scaling Reinforcement Learning from Human Feedback with AI Feedback](https://arxiv.org/abs/2309.00267) - Studies reinforcement learning from AI-generated preferences as a scalable alternative to direct human feedback. (ICML 2024)
 - [Self-Play Fine-Tuning Converts Weak Language Models to Strong Language Models](https://arxiv.org/abs/2401.01335) - Iteratively improves one language model through self-play preference learning without additional human annotations. (ICML 2024)


### PR DESCRIPTION
Update [RecurSE: Bounded Recursive Self-Evaluation for LLM Rubric Judges](https://arxiv.org/abs/2608.24231)

## Summary

Adds RecurSE to `Model-level RSI` → `Self-Training & Self-Reward`, placed after EvoLM to follow same-year title ordering.

## Required RSI submission details

### What is being improved?

The weights of an LLM rubric judge. RecurSE trains the judge with RL using process rewards from a synchronized policy-copy checker that audits the judge's rubric reasoning.

### Does the improvement persist across iterations?

Yes. Updated judge parameters carry forward across training steps. The retained checkpoint (selected by PAV) is the persistent artifact used for later evaluation and for curating preference pairs that improve a downstream policy.

### Is the improvement mechanism itself subject to improvement?

Partially. The checker is a synchronized copy of the evolving judge policy, so the reward-producing auditor co-evolves with the judge. The outer RecurSE loop design (interface decoupling and the PAV early-stopping monitor) is fixed rather than rewritten by the system.

### Why is this specifically relevant to RSI?

It is an explicitly framed bounded recursive self-improvement setting for LLM-as-judge: learning signals come from the model's own evaluative capability rather than gold labels in the RL reward, while PAV monitors reward validity on a compact human-verified holdout to decide when self-improvement must stop.

### Publication status

arXiv preprint (2026): https://arxiv.org/abs/2608.24231

### Public artifacts
Official implementation: Not yet publicly released
Public data / checkpoints: Not yet publicly released
Public evaluation harness: Not yet publicly released

### Evaluation artifact status
Internal

## Checklist

- [x] I searched the list and open pull requests for duplicates.
- [x] I used the resource's official title and canonical URL.
- [x] I placed the entry in the most specific applicable subsection and followed its ordering rules.
- [x] I verified the publication status against a primary or authoritative source.
- [x] npx --yes awesome-lint@2.3.0 passes locally.