### PR TITLE
Add Reef to Frameworks & Tools → Harness / Memory / Skill Evolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ Benchmarks are separated into direct self-improvement evaluations, frontier-lab 
 - [EvolveR](https://github.com/KnowledgeXLab/EvolveR) - Self-evolving LLM-agent framework that improves through a closed-loop, experience-driven lifecycle.
 - [Letta Code](https://github.com/letta-ai/letta-code) - Memory-first coding-agent harness whose long-lived agents rewrite context and learn skills from experience.
 - [Memento-Skills](https://github.com/Memento-Teams/Memento-Skills) - Self-evolving agent framework that retrieves, evaluates, repairs, and rewrites persistent skills through reflective learning.
+- [Reef](https://github.com/Human-Agent-Society/reef) - Continual-learning serving infrastructure that records agent interactions, turns matched feedback into model-weight or harness updates, and publishes accepted updates as versioned artifacts.
 - [Voyager](https://github.com/MineDojo/Voyager) - Embodied lifelong-learning agent with automatic curriculum, iterative prompting, and a reusable skill library.
 
 ### Automated Search / AI R&D


### PR DESCRIPTION
Adds [Reef](https://github.com/Human-Agent-Society/reef) to `Frameworks & Tools` → `Harness / Memory / Skill Evolution`, placed alphabetically between Memento-Skills and Voyager.

> **Disclosure:** I am a maintainer of Reef. Flagging this up front so you can weigh it accordingly.

Answers to the six required questions:

**1. What is being improved?**
Two surfaces behind a live serving endpoint: model **weights**, and the agent **harness** (prompts, skills, configuration). Which surface a deployment updates is selected by its recipe.

**2. Does the improvement persist across iterations?**
Yes. Reef runs a four-step cycle — serve and record interactions → match feedback to recorded interactions → produce an update from eligible records → evaluate the candidate and publish it if accepted. Accepted updates become versioned artifacts that are served to subsequent requests, with version history retained, so the carried-forward artifact is the updated weights or harness rather than a per-task scratchpad.

**3. Is the improvement mechanism itself subject to improvement?**
**No — and I want to be explicit about this rather than overstate it.** The updater, the feedback-matching/eligibility logic, and the evaluation gate are operator-defined and fixed across rounds. Reef is persistent self-improvement, not recursive self-improvement. I am proposing it for the `Frameworks & Tools` subsection alongside entries like Continual Harness and Letta Code, not for any RSI-labelled category.

**4. Why is this specifically relevant to RSI?**
It is a serving-side substrate for the persistent-improvement loop: an evaluate-then-promote gate applied to a live endpoint, with rollback-capable version history over both weights and harness. That combination — keeping traffic served while the served artifact is what changes — is the operational layer the systems already in this section need, and it treats the harness as a first-class update surface rather than only the weights.

**5. Publication status:**
No paper. Open-source project (2026), Apache-2.0, published on PyPI as `reef-infra`.

**6. Public artifacts and evaluation artifact status:**
Code, docs, and recipes are fully public under Apache-2.0. **Not applicable / no evaluation reported** — Reef does not currently publish benchmark results or a reproducible evaluation of its own improvement claims, so it should not be read as carrying empirical evidence. The candidate-evaluation harness itself is in-repo (`reef/train/evaluation/`) and user-supplied per recipe.

Checks: entry uses the section's `- [Name](url) - One sentence.` format, one resource per PR, no duplicate link in the list. `npx --yes awesome-lint@2.3.0` passes on `main` with this entry applied. (On a non-default branch the `remark-lint:awesome-github` rule fails for every state of the tree, including unmodified upstream, so I verified on `main`.)